### PR TITLE
Fixing text discrepancies

### DIFF
--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -17,12 +17,16 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
-    font-weight: 700;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-weight: 200;
+    color:#9E9898;
 }
 
 .topnav {
-    font-size: 14px; 
+    font-size: 18px; 
+    /* For some reason, despite linking to the google font, it defaults to serif
+     * so for now I am commenting this font outs */ 
+    /* font-family: 'open_sansregular'; */
 }
 
 .lead {
@@ -43,22 +47,26 @@ h6 {
     position: relative;
     padding-top: 20%;
     padding-bottom: 20%;
+    color:#ffffff;
 }
 
 .intro-message > h1 {
     margin: 0;
     text-shadow: 2px 2px 3px rgba(0,0,0,0.6);
     font-size: 5em;
+    color:#ffffff;
 }
 
 .intro-divider {
     width: 400px;
     border-top: 1px solid #f8f8f8;
     border-bottom: 1px solid rgba(0,0,0,0.2);
+    color:#ffffff;
 }
 
 .intro-message > h3 {
     text-shadow: 2px 2px 3px rgba(0,0,0,0.6);
+    color:#ffffff;
 }
 
 @media(max-width:767px) {
@@ -186,7 +194,6 @@ p.copyright {
     border-bottom: 1px solid #868686;
     display: inline-block;
     padding: 0 0 0.4em;
-    font-family: 'open_sanssemibold';
 }
 .about-head h3 span{
     color:#FC635E;
@@ -228,7 +235,6 @@ a.wedobtn{
 .wedo-left p{
     color: #9E9898;
     line-height: 1.8em;
-    font-family: 'open_sanslight';
 }
 
 .wedo-grids {
@@ -259,7 +265,6 @@ a.wedobtn{
 .advertising-right p{
     color: #9E9898;
     line-height: 1.8em;
-    font-family: 'open_sanslight';
 }
 
 /*--- portfolio ---*/
@@ -384,7 +389,6 @@ a.wedobtn{
     position:relative;
     display:inline-block;
     vertical-align:top;
-     font-family: 'open_sansregular';
     font-weight: 300;
     overflow:hidden;
     width: 100%;

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
     <!-- Custom Fonts -->
     <link href="font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
This pull request changes the feel of the main landing page by making text on the page more consistent. Zen.

Changes include:  
   - Removing the really western :horse: font that suddenly popped up and replaces it with Helvetica Neue
   - Makes all the text a nice gray except for anything related to the intro class (landing-page.css) 

I was not able to make the navbar open_sansregular like the navbar in your blog... Not too sure why, I'll keep looking into it :panda_face:. Despite this the two fonts are actually surprisingly similar enough that I doubt anyone would notice the difference unless they were as nitpicky as me :v: .